### PR TITLE
Fix issue for ogg filetype in google chrome for AvWaveform

### DIFF
--- a/src/components/AvWaveform.js
+++ b/src/components/AvWaveform.js
@@ -221,7 +221,7 @@ const AvWaveform = {
       const segSize = Math.ceil(buffer.length / this.canvWidth)
       const width = this.canvWidth
       const height = this.canvHeight
-      this.duration = this.audio.duration
+      this.duration = buffer.duration // while we have buffer why we don't use it ?
 
       for (let c = 0; c < buffer.numberOfChannels; c++) {
         const data = buffer.getChannelData(c)


### PR DESCRIPTION
I am using vue-audio-visual for view wave-form. 
but I was stuck with google-chrome. 
like i can see wave-form for mp3 and webm but when i try to play with ogg/audio i am failing. 
and here i find solution for it. 
in `src/components/AvWaveform.js` line #224. i can see `setPeaks` is getting `buffer` but in like #224 you are using `this.audio.duration`. 
so i simply change it to `buffer.duration` and its works like a works like a charm.
if i am wrong please pardon me.