### PR TITLE
Fixes rendering and playing sound in macOS Safari

### DIFF
--- a/src/components/AvBase.js
+++ b/src/components/AvBase.js
@@ -172,6 +172,10 @@ export default {
   mounted () {
     this.createHTMLElements()
 
+    this.audio.onclick = () => {
+      if (!this.audioCtx) this.setAnalyser()
+    }
+
     this.audio.onplay = () => {
       if (!this.audioCtx) this.setAnalyser()
       this.mainLoop()


### PR DESCRIPTION
Partial fix for #25.

Tests pass and components render on macOS Safari, not on iOS Safari yet.