### PR TITLE
add connect-distination property to AvMedia

### DIFF
--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -113,6 +113,16 @@ const props = {
   lineWidth: {
     type: Number,
     default: null
+  },
+
+  /**
+   * prop: 'connect-distination'
+   * Analyser to connect to audio context's destination
+   * Default: true
+   */
+  connectDistination: {
+    type: Boolean,
+    default: true
   }
 }
 
@@ -166,7 +176,9 @@ const AvMedia = {
       } else {
         this.analyser.fftSize = this.type === 'frequ' ? 1024 : 8192
       }
-      this.analyser.connect(this.audioCtx.destination)
+      if (this.connectDistination) {
+        this.analyser.connect(this.audioCtx.destination)
+      }
     },
 
     draw: function () {


### PR DESCRIPTION
Add `connect-distination` property to `AvMedia` so that the audio visualizer can be used with existing audio media source without causing echo.

Right now, you will have to put on a headphone to avoid the echo. Without having analyser connecting to the audio destination, there will be no echo.