### PR TITLE
fix issue with safari cannot instantiate new AudioContext after exception

### DIFF
--- a/src/components/AvBase.js
+++ b/src/components/AvBase.js
@@ -141,8 +141,8 @@ const methods = {
    * Set audio context analyser.
    */
   setAnalyser: function () {
-    this.audioCtx = new AudioContext()
-    this.analyser = this.audioCtx.createAnalyser()
+    this.audioCtx = this.audioCtx || new AudioContext()
+    this.analyser = this.analyser || this.audioCtx.createAnalyser()
     const src = this.audioCtx.createMediaElementSource(this.audio)
 
     src.connect(this.analyser)

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -176,8 +176,8 @@ const AvMedia = {
      * Set analyser
      */
     setAnalyser: function () {
-      this.audioCtx = new AudioContext()
-      this.analyser = this.audioCtx.createAnalyser()
+      this.audioCtx = this.audioCtx || new AudioContext()
+      this.analyser = this.analyser || this.audioCtx.createAnalyser()
       const src = this.audioCtx.createMediaStreamSource(this.media)
 
       src.connect(this.analyser)


### PR DESCRIPTION
Safari won't let you instantiate new AudioContexts if an error was thrown. This can be fixed with the singleton pattern for the AudioContext.