### PR TITLE
Modified the render function according to Vue 3.x syntax

### DIFF
--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -139,6 +139,7 @@ const props = {
 /**
  * Component AvMedia
  */
+import { h } from "vue";
 const AvMedia = {
   name: 'av-media',
   data () {
@@ -149,7 +150,9 @@ const AvMedia = {
     }
   },
   props,
-  render: h => h('div'),
+  render () {
+    return h('div')
+  },
   mounted () {
     this.createCanvas()
   },
@@ -264,7 +267,7 @@ const AvMedia = {
 
         const bits = Math.round(
           data.slice(index, index + arcStep).reduce((v, t) => t + v, 0) /
-            arcStep
+          arcStep
         )
 
         const blen = r + (bits / 255.0) * barLen

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -1,4 +1,4 @@
-import { h } from "vue";
+import { h } from "vue"
 /**
  * Component props
  */

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -1,10 +1,11 @@
+import { h } from "vue";
 /**
  * Component props
  */
 const props = {
   /**
    * prop: 'media'
-   * MediaStream object for visualisation. Can be delivered by
+   * MediaStream object for visualization. Can be delivered by
    * Web Audio API functions like getUserMedia or RTCPeerConnection
    */
   media: {
@@ -139,7 +140,6 @@ const props = {
 /**
  * Component AvMedia
  */
-import { h } from "vue";
 const AvMedia = {
   name: 'av-media',
   data () {


### PR DESCRIPTION
This fix solves `Uncaught (in promise) TypeError: h is not a function`  error and makes the plugin usable in Vue 3 projects. 