### PR TITLE
Fix imports to remove warnings and support Vue2 & Vue3

### DIFF
--- a/src/components/AvBase.js
+++ b/src/components/AvBase.js
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import * as vue from 'vue'
 /**
  * Mixin component with base and common properties and functions.
  */
@@ -170,9 +170,9 @@ const methods = {
 export default {
   props,
   render (hv2) {
-    if (h) {
+    if (vue.h) {
       // Vue3 render
-      return h('div')
+      return vue.h('div')
     }
     // Vue2 render
     return hv2('div')

--- a/src/components/AvBase.js
+++ b/src/components/AvBase.js
@@ -170,9 +170,10 @@ const methods = {
 export default {
   props,
   render (hv2) {
-    if (vue.h) {
+    const { h } = vue;
+    if (h) {
       // Vue3 render
-      return vue.h('div')
+      return h('div')
     }
     // Vue2 render
     return hv2('div')

--- a/src/components/AvBase.js
+++ b/src/components/AvBase.js
@@ -170,7 +170,7 @@ const methods = {
 export default {
   props,
   render (hv2) {
-    const { h } = vue;
+    const { h } = vue
     if (h) {
       // Vue3 render
       return h('div')

--- a/src/components/AvBase.js
+++ b/src/components/AvBase.js
@@ -167,10 +167,12 @@ const methods = {
   }
 }
 
+// A fix for webpack warnings across vue2 & vue3
+const h = vue['h'[0]]
+
 export default {
   props,
   render (hv2) {
-    const { h } = vue
     if (h) {
       // Vue3 render
       return h('div')

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -150,6 +150,9 @@ const props = {
   }
 }
 
+// A fix for webpack warnings across vue2 & vue3
+const h = vue['h'[0]]
+
 /**
  * Component AvMedia
  */
@@ -164,7 +167,6 @@ const AvMedia = {
   },
   props,
   render (hv2) {
-    const { h } = vue
     if (h) {
       // Vue3 render
       return h('div')

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -164,9 +164,10 @@ const AvMedia = {
   },
   props,
   render (hv2) {
-    if (vue.h) {
+    const { h } = vue;
+    if (h) {
       // Vue3 render
-      return vue.h('div')
+      return h('div')
     }
     // Vue2 render
     return hv2('div')

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import * as vue from 'vue'
 /**
  * Component props
  */
@@ -164,9 +164,9 @@ const AvMedia = {
   },
   props,
   render (hv2) {
-    if (h) {
+    if (vue.h) {
       // Vue3 render
-      return h('div')
+      return vue.h('div')
     }
     // Vue2 render
     return hv2('div')

--- a/src/components/AvMedia.js
+++ b/src/components/AvMedia.js
@@ -164,7 +164,7 @@ const AvMedia = {
   },
   props,
   render (hv2) {
-    const { h } = vue;
+    const { h } = vue
     if (h) {
       // Vue3 render
       return h('div')


### PR DESCRIPTION
This removes the `"export 'h' was not found in 'vue'` warning some may be seeing in Vue2 while maintaining compatibility with Vue2 & Vue3